### PR TITLE
feat: add ecs service for order api and order processor

### DIFF
--- a/deliverables/deploy/ecr/terraform/Makefile
+++ b/deliverables/deploy/ecr/terraform/Makefile
@@ -1,0 +1,22 @@
+THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
+THIS_DIR      := $(dir $(realpath $(THIS_MAKEFILE)))
+
+.PHONY: tf-ecr-init
+tf-ecr-init:
+	@@cd $(THIS_DIR) && terraform init 
+
+.PHONY: tf-ecr-destroy
+tf-ecr-destroy:
+	@@cd $(THIS_DIR) && terraform destroy
+
+.PHONY: tf-ecr-apply
+tf-ecr-apply: tf-ecr-plan
+	@@cd $(THIS_DIR) && terraform apply tfplan.json
+
+.PHONY: tf-ecr-plan
+tf-ecr-plan:
+	@@cd $(THIS_DIR) && terraform plan -out tfplan.json
+
+.PHONY: tf-ecr-graph
+tf-ecr-graph:
+	@@cd $(THIS_DIR) && terraform graph -type=plan

--- a/deliverables/deploy/ecs-ec2/terraform/_outputs.tf
+++ b/deliverables/deploy/ecs-ec2/terraform/_outputs.tf
@@ -5,7 +5,7 @@ output "vpc_id" {
 
 output "alb_dns_name" {
   description = "DNS name of the load balancer"
-  value       =  module.ecs[0].alb_dns_name 
+  value       =  module.ecs.alb_dns_name 
 }
 
 output "dynamodb_orders_table" {

--- a/deliverables/deploy/ecs-ec2/terraform/_variables.tf
+++ b/deliverables/deploy/ecs-ec2/terraform/_variables.tf
@@ -37,19 +37,23 @@ variable "private_subnets_cidr" {
 variable "order_api_image" {
   description = "Docker image for Order API"
   type        = string
+  #default     = "971422690011.dkr.ecr.eu-west-1.amazonaws.com/devopstht-order-api:latest"
 }
 
 variable "processor_image" {
   description = "Docker image for Order Processor"
   type        = string
+  #default     = "971422690011.dkr.ecr.eu-west-1.amazonaws.com/devopstht-order-processor:latest"
 }
 
 variable "order_api_repo_arn" {
   description = "ECR Repo ARN for Order API"
   type        = string
+  #default     = "arn:aws:ecr:eu-west-1:971422690011:repository/devopstht-order-api"
 }
 
 variable "order_processor_repo_arn" {
   description = "ECR Repo ARN for Order Processor"
   type        = string
+  #default     = "arn:aws:ecr:eu-west-1:971422690011:repository/devopstht-order-processor"
 }

--- a/deliverables/deploy/ecs-ec2/terraform/main.tf
+++ b/deliverables/deploy/ecs-ec2/terraform/main.tf
@@ -83,7 +83,6 @@ module "dynamodb" {
   environment = var.environment
 }
 
-
 module "security" {
   source = "./modules/security"
 

--- a/deliverables/deploy/ecs-ec2/terraform/modules/dynamodb/_variables.tf
+++ b/deliverables/deploy/ecs-ec2/terraform/modules/dynamodb/_variables.tf
@@ -26,3 +26,27 @@ variable "inventory_hash_key" {
   type        = string
   default     = "product_id"
 }
+
+variable "orders_read_capacity" {
+  description = "Read capacity for orders table"
+  type        = number
+  default     = 1
+}
+
+variable "orders_write_capacity" {
+  description = "Write capacity for orders table"
+  type        = number
+  default     = 1
+}
+
+variable "inventory_read_capacity" {
+  description = "Read capacity for inventory table"
+  type        = number
+  default     = 1
+}
+
+variable "inventory_write_capacity" {
+  description = "Write capacity for inventory table"
+  type        = number
+  default     = 1
+}

--- a/deliverables/deploy/ecs-ec2/terraform/modules/dynamodb/_variables.tf
+++ b/deliverables/deploy/ecs-ec2/terraform/modules/dynamodb/_variables.tf
@@ -2,3 +2,27 @@ variable "environment" {
   description = "Environment name"
   type        = string
 }
+
+variable "orders_table_name" {
+  description = "Name of the orders table"
+  type        = string
+  default     = "orders"
+}
+
+variable "inventory_table_name" {
+  description = "Name of the inventory table"
+  type        = string
+  default     = "inventory"
+}
+
+variable "orders_hash_key" {
+  description = "Hash key for the orders table"
+  type        = string
+  default     = "order_id"
+}
+
+variable "inventory_hash_key" {
+  description = "Hash key for the inventory table"
+  type        = string
+  default     = "product_id"
+}

--- a/deliverables/deploy/ecs-ec2/terraform/modules/dynamodb/main.tf
+++ b/deliverables/deploy/ecs-ec2/terraform/modules/dynamodb/main.tf
@@ -1,2 +1,21 @@
-######################################################################################## 
-# Add you Code Here to create a DynamoDB Tables for Orders and Inventory
+resource "aws_dynamodb_table" "orders" {
+  name           = "${var.environment}-${var.orders_table_name}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = var.orders_hash_key
+
+  attribute {
+    name = var.orders_hash_key
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table" "inventory" {
+  name           = "${var.environment}-${var.inventory_table_name}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = var.inventory_hash_key
+
+  attribute {
+    name = var.inventory_hash_key
+    type = "S"
+  }
+}

--- a/deliverables/deploy/ecs-ec2/terraform/modules/dynamodb/main.tf
+++ b/deliverables/deploy/ecs-ec2/terraform/modules/dynamodb/main.tf
@@ -1,7 +1,9 @@
 resource "aws_dynamodb_table" "orders" {
   name           = "${var.environment}-${var.orders_table_name}"
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = var.orders_hash_key
+  billing_mode   = "PROVISIONED"
+  read_capacity  = var.orders_read_capacity
+  write_capacity = var.orders_write_capacity
+  hash_key       = var.orders_hash_key
 
   attribute {
     name = var.orders_hash_key
@@ -11,8 +13,10 @@ resource "aws_dynamodb_table" "orders" {
 
 resource "aws_dynamodb_table" "inventory" {
   name           = "${var.environment}-${var.inventory_table_name}"
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = var.inventory_hash_key
+  billing_mode   = "PROVISIONED"
+  read_capacity  = var.inventory_read_capacity
+  write_capacity = var.inventory_write_capacity
+  hash_key       = var.inventory_hash_key
 
   attribute {
     name = var.inventory_hash_key

--- a/deliverables/deploy/ecs-ec2/terraform/modules/ecs/alb.tf
+++ b/deliverables/deploy/ecs-ec2/terraform/modules/ecs/alb.tf
@@ -15,7 +15,7 @@ resource "aws_lb_target_group" "order_api" {
   name        = "${var.environment}-order-api-tg"
   port        = 80
   protocol    = "HTTP"
-  target_type = "instance"
+  target_type = "ip"
 
   health_check {
     healthy_threshold   = 2
@@ -24,6 +24,7 @@ resource "aws_lb_target_group" "order_api" {
     interval            = 10
     path                = "/health"
     matcher             = "200"
+    port                = 8000
   }
 }
 

--- a/deliverables/deploy/ecs-ec2/terraform/modules/ecs/main.tf
+++ b/deliverables/deploy/ecs-ec2/terraform/modules/ecs/main.tf
@@ -6,4 +6,174 @@ resource "aws_ecs_cluster" "main" {
     value = "enabled"
   }
 }
-###################### ECS SERVICES AND TASK DEFINITIONS HERE
+
+resource "aws_ecs_task_definition" "order_api" {
+  family             = "${var.environment}-order-api"
+  network_mode       = "awsvpc"
+  cpu                = 256
+  memory             = 512
+  execution_role_arn = var.ecs_execution_role_arn
+  task_role_arn      = var.ecs_task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "order-api",
+      image = var.order_api_image,
+      portMappings = [
+      {
+        containerPort = 8000  
+        protocol      = "tcp"
+        name          = "http" 
+      }
+    ],
+      environment = [
+        {
+          name  = "ORDERS_TABLE_NAME"
+          value = "${var.orders_table_name}"
+        },
+        {
+          name  = "DYNAMODB_TABLE"
+          value = var.orders_table_name
+        },
+        {
+          name  = "AWS_REGION"
+          value = var.aws_region
+        },
+        {
+          name  = "ORDER_PROCESSOR_URL"
+          value = "http://order-processor.devopstht.internal:8000" 
+        },
+      ],
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = "/ecs/${var.environment}-order-api"
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "order-api"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "order_api" {
+  name            = "${var.environment}-order-api-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.order_api.arn
+  desired_count   = 1
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.order_api.arn
+    container_name   = "order-api"
+    container_port   = 8000
+  }
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_private_dns_namespace.main.arn
+    service {
+      discovery_name = "order-api"
+      port_name      = "http"
+      client_alias {
+        dns_name = "order-api.${var.environment}.internal"
+        port     = 8000
+      }
+    }
+  }
+
+  network_configuration {
+    subnets          = var.private_subnets
+    security_groups  = [var.ecs_security_group_id]
+    assign_public_ip = false
+  }
+
+  depends_on = [aws_ecs_task_definition.order_api,aws_ecs_service.order_processor]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+
+resource "aws_ecs_task_definition" "order_processor" {
+  family             = "${var.environment}-order-processor"
+  network_mode       = "awsvpc"
+  cpu                = 256
+  memory             = 512
+  execution_role_arn = var.ecs_execution_role_arn
+  task_role_arn      = var.ecs_task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "order-processor",
+      image = var.processor_image,
+      portMappings = [
+      {
+        containerPort = 8000  
+        protocol      = "tcp"
+        name          = "http" 
+      }
+    ],
+      environment = [
+        {
+          name  = "INVENTORY_TABLE_NAME"
+          value = "${var.inventory_table_name}"
+        },
+        {
+          name  = "DYNAMODB_TABLE"
+          value = "${var.inventory_table_name}"
+        },
+        {
+          name  = "AWS_REGION"
+          value = var.aws_region
+        }
+      ],
+       logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = "/ecs/${var.environment}-order-processor"
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "order-processor"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "order_processor" {
+  name            = "${var.environment}-order-processor-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.order_processor.arn
+  desired_count   = 1
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_private_dns_namespace.main.arn
+    service {
+      discovery_name = "order-processor"
+      port_name      = "http"
+      client_alias {
+        dns_name = "order-processor.${var.environment}.internal"
+        port     = 8000
+      }
+    }
+  }
+
+   network_configuration {
+    subnets          = var.private_subnets
+    security_groups  = [var.ecs_security_group_id]
+    assign_public_ip = false
+  }
+  depends_on = [aws_ecs_task_definition.order_processor]
+}
+
+
+resource "aws_cloudwatch_log_group" "order_api_logs" {
+  name              = "/ecs/${var.environment}-order-api"
+  retention_in_days = 7  # Adjust as needed
+}
+
+resource "aws_cloudwatch_log_group" "order_processor_logs" {
+  name              = "/ecs/${var.environment}-order-processor"
+  retention_in_days = 7  # Adjust as needed
+}

--- a/deliverables/deploy/ecs-ec2/terraform/modules/security/main.tf
+++ b/deliverables/deploy/ecs-ec2/terraform/modules/security/main.tf
@@ -4,8 +4,8 @@ resource "aws_security_group" "ecs_tasks" {
   vpc_id      = var.vpc_id
 
   ingress {
-    from_port       = 32768
-    to_port         = 65535
+    from_port       = 8000
+    to_port         = 8000
     protocol        = "tcp"
     security_groups = [aws_security_group.alb.id]
   }
@@ -58,4 +58,14 @@ resource "aws_security_group" "alb" {
 
   tags = { Name = "${var.environment}-alb-sg" }
 
+}
+
+# Allow order-api to communicate with order-processor
+resource "aws_security_group_rule" "ecs_tasks" {
+  type              = "ingress"
+  from_port         = 8000
+  to_port           = 8000
+  protocol          = "tcp"
+  security_group_id = aws_security_group.ecs_tasks.id
+  source_security_group_id = aws_security_group.ecs_tasks.id
 }

--- a/deliverables/deploy/ecs-ec2/terraform/modules/vpc/remotes.tf
+++ b/deliverables/deploy/ecs-ec2/terraform/modules/vpc/remotes.tf
@@ -1,0 +1,3 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/starter/apps/order-api/src/main.py
+++ b/starter/apps/order-api/src/main.py
@@ -40,9 +40,11 @@ DYNAMODB_ENDPOINT = os.getenv("DYNAMODB_ENDPOINT", None)
 
 DYNAMODB_TABLE = os.getenv("DYNAMODB_TABLE", "orders")
 
+AWS_REGION = os.getenv("AWS_REGION", None)
+
 ORDER_PROCESSOR_URL = os.getenv("ORDER_PROCESSOR_URL", "http://localhost:8001")
 
-dynamodb = boto3.resource("dynamodb", endpoint_url=DYNAMODB_ENDPOINT)
+dynamodb = boto3.resource("dynamodb", endpoint_url=DYNAMODB_ENDPOINT,region_name=AWS_REGION)
 orders_table = dynamodb.Table(DYNAMODB_TABLE)
 
 

--- a/starter/apps/order-processor/src/main.py
+++ b/starter/apps/order-processor/src/main.py
@@ -9,6 +9,7 @@ from typing import Dict, Any, Optional
 
 DYNAMODB_ENDPOINT=os.getenv("DYNAMODB_ENDPOINT", None)
 DYNAMODB_TABLE=os.getenv("DYNAMODB_TABLE", "inventory")
+AWS_REGION = os.getenv("AWS_REGION", None)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title="Order Processor")
 
 dynamodb = boto3.resource(
-    "dynamodb", endpoint_url=DYNAMODB_ENDPOINT)
+    "dynamodb", endpoint_url=DYNAMODB_ENDPOINT,region_name=AWS_REGION)
 
 inventory_table = dynamodb.Table(DYNAMODB_TABLE)
 


### PR DESCRIPTION
This pull request includes several changes to the Terraform configurations and Python applications to enhance the deployment and functionality of the order management system. The most important changes include adding new resources for DynamoDB tables, updating ECS task definitions and services, modifying security group rules, and updating environment variable handling in the Python applications.

### Terraform Configuration Changes:

* [`deliverables/deploy/ecr/terraform/Makefile`](diffhunk://#diff-1423948b00f87ce2eb020c9c85a16ce70126d8ed517bc277a57b8f8e30493d18R1-R22): Added Makefile targets for initializing, planning, applying, and destroying Terraform configurations for ECR.
* [`deliverables/deploy/ecs-ec2/terraform/modules/dynamodb/main.tf`](diffhunk://#diff-82647e9b8ec495580c476f72f3f9b889c585349291a153fabd19b555893dd002L1-R25): Added resources to create DynamoDB tables for orders and inventory.
* [`deliverables/deploy/ecs-ec2/terraform/modules/ecs/main.tf`](diffhunk://#diff-9ccd204ee0f94ad40deef53c1179a8c8b20347cd066f044bb77cd12ff0d25b89L9-R179): Added ECS task definitions and services for `order_api` and `order_processor`, including container definitions and network configurations.
* [`deliverables/deploy/ecs-ec2/terraform/modules/security/main.tf`](diffhunk://#diff-264e1a2209af919340211d71e1d2d356a46a0fc3a45eb84955d391b71c744b82L7-R8): Updated security group rules to allow communication between `order_api` and `order_processor` on port 8000. [[1]](diffhunk://#diff-264e1a2209af919340211d71e1d2d356a46a0fc3a45eb84955d391b71c744b82L7-R8) [[2]](diffhunk://#diff-264e1a2209af919340211d71e1d2d356a46a0fc3a45eb84955d391b71c744b82R62-R71)
* [`deliverables/deploy/ecs-ec2/terraform/modules/vpc/remotes.tf`](diffhunk://#diff-1fcbf959574b9fe5ef751a9e72b1a3325cf43c7e57ba53177d4ad5711906ef01R1-R3): Added data source to retrieve available AWS availability zones.

### Python Application Changes:

* [`starter/apps/order-api/src/main.py`](diffhunk://#diff-61dbe156e50528ba95cd6ecd14502ba6567669c52011d3b6730e4c355d8490eeR43-R47): Updated to include `AWS_REGION` environment variable and pass it to the DynamoDB resource initialization.
* [`starter/apps/order-processor/src/main.py`](diffhunk://#diff-73da53174e6e91bdee8a66928f9f8f5b74cde315d09fd25c0bfe11baaae9def1R12): Updated to include `AWS_REGION` environment variable and pass it to the DynamoDB resource initialization. [[1]](diffhunk://#diff-73da53174e6e91bdee8a66928f9f8f5b74cde315d09fd25c0bfe11baaae9def1R12) [[2]](diffhunk://#diff-73da53174e6e91bdee8a66928f9f8f5b74cde315d09fd25c0bfe11baaae9def1L24-R25)